### PR TITLE
OWL-2649 Removing the extra padding from SideNav in chrome

### DIFF
--- a/reference/library/src/morpheus-owl/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-owl/sass/modules/_toolmenu.scss
@@ -197,6 +197,7 @@ nav#subSites{
 		padding: 0;
 		margin:  0;
 		li{
+			line-height: 0;
 			&.#{$namespace}collapseTools
 			{
 				display:flex;


### PR DESCRIPTION
https://jira.uwo.ca/browse/OWL-2649

Round two.

Separate feature branch and all that good stuff.

Fixes an issue where in Chrome the side navigation has extra padding/space above it (both when collapsed and not)