### PR TITLE
OWL-2713: Site Info > Manage Participants > Clickable table heading link's underline cuts off the bottom of the text

### DIFF
--- a/site-manage/site-manage-site-participant-helper/src/webapp/css/sitemanage.css
+++ b/site-manage/site-manage-site-participant-helper/src/webapp/css/sitemanage.css
@@ -2,7 +2,6 @@ table tr th.wicket_orderDown span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/sortdescending.gif);
@@ -14,7 +13,6 @@ table tr th.wicket_orderUp span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/sortascending.gif);
@@ -26,7 +24,6 @@ table tr th.wicket_orderNone span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/checkoff.gif);

--- a/site-manage/site-manage-site-participant-helper/src/webapp/css/sitemanage.css
+++ b/site-manage/site-manage-site-participant-helper/src/webapp/css/sitemanage.css
@@ -2,7 +2,7 @@ table tr th.wicket_orderDown span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    vertical-align: middle;
+    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/sortdescending.gif);
@@ -14,7 +14,7 @@ table tr th.wicket_orderUp span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    vertical-align: middle;
+    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/sortascending.gif);
@@ -26,7 +26,7 @@ table tr th.wicket_orderNone span {
     background: transparent;
     text-align: left;
     margin-right: .2em;
-    vertical-align: middle;
+    /*vertical-align: middle;*/
     background-position: right;
     background-repeat:no-repeat;
     background-image: url(/library/image/sakai/checkoff.gif);


### PR DESCRIPTION
https://jira.uwo.ca/browse/OWL-2713

Removing the vertical align fixes the underline issue in Firefox and does not appear to cause issues in Chrome / Other Browsers.