### PR TITLE
56022 remove old check for CR applicability added in OWL-2554 

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -17644,11 +17644,7 @@ public class AssignmentAction extends PagedResourceActionII
 						// of further permissions
 						m_securityService.pushAdvisor(sa);
 						ContentResource attachment = m_contentHostingService.addAttachmentResource(resourceId, siteId, "Assignments", contentType, fileContentStream, props);
-						if(allowReviewService && !contentReviewService.isAcceptableContent(attachment)) {
-							addAlert(state, rb.getFormattedMessage("cr.notprocess.warning"));
-						} else if(!contentReviewService.isAcceptableSize(attachment)) {
-							addAlert(state, rb.getFormattedMessage("cr.size.warning"));
-						}						
+						
 						Site s = null;
 						try
 						{


### PR DESCRIPTION
but added in community code differently in SAK-27587.

The result is that if an instructor creates a non-CR Assignment, the student receives a key not found error (cr.notprocess.warning) if they attempt to submit a document that TII can't handle.